### PR TITLE
disable UTF-8 cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -246,7 +246,7 @@ EmptyLiteral:
 
 Encoding:
   Description: 'Use UTF-8 as the source file encoding.'
-  Enabled: true
+  Enabled: false 
 
 EndAlignment:
   Enabled: false


### PR DESCRIPTION
With the value set to true, "# encoding: UTF-8" is needed at the beginning of each file. Ruby 2.0 uses utf-8 by default.
